### PR TITLE
get_emails-query returned duplicate rows (which get de-duplicated lat…

### DIFF
--- a/modules/Accounts/Accounts.php
+++ b/modules/Accounts/Accounts.php
@@ -496,7 +496,8 @@ class Accounts extends CRMEntity {
 				AND vtiger_crmentity.crmid = vtiger_activity.activityid
 				AND vtiger_activity.activitytype='Emails'
 				AND vtiger_account.accountid = ".$id."
-				AND vtiger_crmentity.deleted = 0";
+				AND vtiger_crmentity.deleted = 0
+                GROUP BY vtiger_activity.activityid";
 
 		$return_value = GetRelatedList($this_module, $related_module, $other, $query, $button, $returnset);
 


### PR DESCRIPTION
…er when fetching results) which broke LIMITs (which broke "next page"-button in related list). Fast&easy fix by adding GROUP BY (query should probably be rewritten from scratch)