### PR TITLE
Prevent entity-encoding when fetching data of related lists, so strin…

### DIFF
--- a/modules/Vtiger/models/Relation.php
+++ b/modules/Vtiger/models/Relation.php
@@ -176,10 +176,9 @@ class Vtiger_Relation_Model extends Vtiger_Base_Model{
 			$query .= ' AND label = ?';
 			$params[] = html_entity_decode($label);
 		}
-		
+
 		$result = $db->pquery($query, $params);
-		if($db->num_rows($result)) {
-			$row = $db->query_result_rowdata($result, 0);
+		while ($row =$db->fetchByAssoc($result,-1,false)) {
 			$relationModelClassName = Vtiger_Loader::getComponentClassName('Model', 'Relation', $parentModuleModel->get('name'));
 			$relationModel = new $relationModelClassName();
 			$relationModel->setData($row)->setParentModuleModel($parentModuleModel)->setRelationModuleModel($relatedModuleModel);
@@ -208,8 +207,7 @@ class Vtiger_Relation_Model extends Vtiger_Base_Model{
 
 		$relationModels = array();
 		$relationModelClassName = Vtiger_Loader::getComponentClassName('Model', 'Relation', $parentModuleModel->get('name'));
-		for($i=0; $i<$db->num_rows($result); $i++) {
-			$row = $db->query_result_rowdata($result, $i);
+		while ($row =$db->fetchByAssoc($result,-1,false)) {
 			//$relationModuleModel = Vtiger_Module_Model::getCleanInstance($moduleName);
 			// Skip relation where target module does not exits or is no permitted for view.
 			if (!Users_Privileges_Model::isPermitted($row['modulename'],'DetailView')) {


### PR DESCRIPTION
…g-comparisions in template won't fail for lists with labels containing umlauts