### PR TITLE
Improved installer: Reenabled php.ini directives test, updated recomm…

### DIFF
--- a/includes/runtime/Viewer.php
+++ b/includes/runtime/Viewer.php
@@ -66,6 +66,9 @@ class Vtiger_Viewer extends SmartyBC {
 		if (!file_exists($compileDir)) {
 			mkdir($compileDir, 0777, true);
 		}
+        if (!is_writable($compileDir)) {
+            die("Fatal error: Smarty compile directory not writable. Please fix permissions under /test/templates_c/.");
+        }
 		$this->setTemplateDir(array($templatesDir));
 		$this->setCompileDir($compileDir);		
 

--- a/modules/Install/actions/ajaxInitDB.php
+++ b/modules/Install/actions/ajaxInitDB.php
@@ -20,7 +20,7 @@ class Install_ajaxInitDB_Action extends Vtiger_BasicAjax_Action {
 		$ret = array(false, 'Unknown error');
 		$mode = $request->get('mode');
 		if (!$this->checkPermission()) {
-			$ret[1] = 'Already Installed';
+			$ret[1] = 'Already installed<br>(if this is in error, delete /test/installFinished)';
 			$mode = 'failed';
 		}
 		$path = Install_Utils_Model::INSTALL_LOG;

--- a/modules/Install/models/Utils.php
+++ b/modules/Install/models/Utils.php
@@ -27,10 +27,6 @@ class Install_Utils_Model {
 		'Cron Modules Directory' => './cron/modules/',
 		'Vtlib Test Directory' => './test/vtlib/',
 		'Vtlib Test HTML Directory' => './test/vtlib/HTML',
-		'Mail Merge Template Directory' => './test/wordtemplatedownload/',
-		'Product Image Directory' => './test/product/',
-		'User Image Directory' => './test/user/',
-		'Contact Image Directory' => './test/contact/',
 		'Logo Directory' => './test/logo/',
 		'Logs Directory' => './logs/',
 	);
@@ -62,57 +58,37 @@ class Install_Utils_Model {
 	}
 
 	/**
-	 * Function returns the php.ini file settings required for installing vtigerCRM
+	 * Function returns the php.ini file settings required for production operation
 	 * @return <Array>
 	 */
 	static function getCurrentDirectiveValue() {
 		$directiveValues = array();
-		if (ini_get('safe_mode') == '1' || stripos(ini_get('safe_mode'), 'On') > -1)
-			$directiveValues['safe_mode'] = 'On';
-		if (ini_get('display_errors') != '1' || stripos(ini_get('display_errors'), 'Off') > -1)
-			$directiveValues['display_errors'] = 'Off';
-		if (ini_get('file_uploads') != '1' || stripos(ini_get('file_uploads'), 'Off') > -1)
+		if (ini_get('file_uploads') != '1' && stripos(ini_get('file_uploads'), 'On') === false)
 			$directiveValues['file_uploads'] = 'Off';
-		if (ini_get('register_globals') == '1' || stripos(ini_get('register_globals'), 'On') > -1)
-			$directiveValues['register_globals'] = 'On';
 		if (ini_get(('output_buffering') < '4096' && ini_get('output_buffering') != '0') || stripos(ini_get('output_buffering'), 'Off') > -1)
 			$directiveValues['output_buffering'] = 'Off';
-		if (ini_get('max_execution_time') != 0)
+		if (ini_get('max_execution_time') < 3600)
 			$directiveValues['max_execution_time'] = ini_get('max_execution_time');
-		if (ini_get('memory_limit') < 32)
+		if (ini_get('memory_limit') < 512)
 			$directiveValues['memory_limit'] = ini_get('memory_limit');
-		$errorReportingValue = E_WARNING & ~E_NOTICE;
-                if(version_compare(PHP_VERSION, '5.5.0') >= 0){
-                    $errorReportingValue = E_WARNING & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT;
-                }
-                else if(version_compare(PHP_VERSION, '5.3.0') >= 0) {
-			$errorReportingValue = E_WARNING & ~E_NOTICE & ~E_DEPRECATED;
-		}
-		if (ini_get('error_reporting') != $errorReportingValue)
-			$directiveValues['error_reporting'] = 'NOT RECOMMENDED';
-		if (ini_get('log_errors') == '1' || stripos(ini_get('log_errors'), 'On') > -1)
-			$directiveValues['log_errors'] = 'On';
-		if (ini_get('short_open_tag') != '1' || stripos(ini_get('short_open_tag'), 'Off') > -1)
+		if (ini_get('short_open_tag') == '1' || stripos(ini_get('short_open_tag'), 'On') > -1)
 			$directiveValues['short_open_tag'] = 'Off';
-
+        if (ini_get('max_input_vars') < 8192)
+			$directiveValues['max_input_vars'] = ini_get('max_input_vars');
 		return $directiveValues;
 	}
 
 	/**
-	 * Variable has the recommended php settings for smooth running of vtigerCRM
+	 * Variable has the recommended php settings for production operation
 	 * @var <Array>
 	 */
 	public static $recommendedDirectives = array (
-		'safe_mode' => 'Off',
-		'display_errors' => 'On',
 		'file_uploads' => 'On',
-		'register_globals' => 'On',
 		'output_buffering' => 'On',
-		'max_execution_time' => '0',
-		'memory_limit' => '32',
-		'error_reporting' => 'E_WARNING & ~E_NOTICE',
-		'log_errors' => 'Off',
-		'short_open_tag' => 'On'
+		'max_execution_time' => '3600',
+		'memory_limit' => '512',
+		'short_open_tag' => 'Off',
+        'max_input_vars' => 8192
 	);
 
 	/**

--- a/modules/Install/views/Index.php
+++ b/modules/Install/views/Index.php
@@ -87,7 +87,7 @@ class Install_Index_view extends Vtiger_View_Controller {
 		$viewer = $this->getViewer($request);
 		$moduleName = $request->getModule();
 		$viewer->assign('FAILED_FILE_PERMISSIONS', Install_Utils_Model::getFailedPermissionsFiles());
-		// $viewer->assign('PHP_INI_CURRENT_SETTINGS', Install_Utils_Model::getCurrentDirectiveValue());
+		$viewer->assign('PHP_INI_CURRENT_SETTINGS', Install_Utils_Model::getCurrentDirectiveValue());
 		$viewer->assign('PHP_INI_RECOMMENDED_SETTINGS', Install_Utils_Model::getRecommendedDirectives());
 		$viewer->assign('SYSTEM_PREINSTALL_PARAMS', Install_Utils_Model::getSystemPreInstallParameters());
 		$viewer->view('Step3.tpl', $moduleName);

--- a/modules/Vtiger/actions/BasicAjax.php
+++ b/modules/Vtiger/actions/BasicAjax.php
@@ -8,6 +8,9 @@
  * All Rights Reserved.
  *************************************************************************************/
 
+// if display_errors is enabled, suppress notices and warnings for ajax calls to not break JSON responses
+error_reporting(E_ALL & ~E_NOTICE & ~E_WARNING & ~E_DEPRECATED);
+
 class Vtiger_BasicAjax_Action extends Vtiger_Action_Controller {
 
 	function checkPermission(Vtiger_Request $request) {


### PR DESCRIPTION
…ended values with those given in installation instructions. Removed non-existing folders from writability check. Provide extra error message if smarty compiled template dir is not writable. Set error_reporting for ajax handlers to only display "real" errors (if display_errors is enabled), so warnings and notices won't break JSON responses. Provide hint about lockfile /test/installFinished if a previous installation had failed.