### PR TITLE
First attempt at naming the new ajax text fieldtypes. Increased width…

### DIFF
--- a/languages/de_de/Settings/LayoutEditor.php
+++ b/languages/de_de/Settings/LayoutEditor.php
@@ -57,7 +57,8 @@ $languageStrings = array(
 	'LBL_SUMMARY_FIELD' => 'kompakte Ansicht',
 	'LBL_WRONG_FIELD_TYPE' => 'falscher Feldtyp',
 	'MultiSelectCombo'=>'Multi-Auswahlliste',
-    'AutocompletedText'=>'Selbstvervollständigend',
+    'AutocompletedText'=>'Selbstvervollständigender Text aus Liste',
+    'AutocompletedSingleUse'=>'Selbstvervollständigende Einmalwahl aus Liste',
 	'Percent'=>'Prozent',
 	'Phone'=>'Telefon',
 	'PickList'=>'Auswahlliste',
@@ -68,6 +69,7 @@ $languageStrings = array(
 	'URL' => 'URL',
 	'LBL_HELPTEXT_VALUE' => 'Hilfetext',
     'LBL_PICKLIST_ROLE_HELP' => 'Bei rollenbasierten Auswahllisten können Sie einzelne Listen-Einträge nur bestimmten Nutzergruppen zur Verfügung stellen sowie die Anzeige von Blöcken von bestimmten Einträgen abhängig machen.<br>Bitte entnehmen Sie die Details dem Handbuch.',
+	'Picklist'=>'Auswahlliste',
 
 );
 

--- a/languages/en_us/Settings/LayoutEditor.php
+++ b/languages/en_us/Settings/LayoutEditor.php
@@ -56,6 +56,8 @@ $languageStrings = array(
 	'LBL_SUMMARY_FIELD' => 'Summary View',
 	'LBL_WRONG_FIELD_TYPE' => 'Wrong Field Type',
 	'MultiSelectCombo'=>'Multi-Select Combo Box',
+    'AutocompletedText'=>'Autocompleted text from list',
+    'AutocompletedSingleUse'=>'Autocompleted text from list for single use',
 	'Percent'=>'Percent',
 	'Phone'=>'Phone',
 	'PickList'=>'Pick List',
@@ -66,6 +68,7 @@ $languageStrings = array(
 	'URL' => 'URL',
 	'LBL_HELPTEXT_VALUE' => 'Help Text',
     'LBL_PICKLIST_ROLE_HELP' => 'Role based picklists allow to make selected entries only available to certain user groups, and to control the display of blocks in dependence of certain values.<br>Please see the manual for details.',
+	'Picklist'=>'Picklist',
 
 );
 

--- a/layouts/vlayout/modules/Settings/LayoutEditor/Index.tpl
+++ b/layouts/vlayout/modules/Settings/LayoutEditor/Index.tpl
@@ -621,18 +621,16 @@
                     {vtranslate('LBL_SELECT_FIELD_TYPE', $QUALIFIED_MODULE)}
                 </span>
                 <div class="controls">
-                    <span class="row-fluid">
-                        <select class="fieldTypesList span7" name="fieldType">
-                            {foreach item=FIELD_TYPE from=$ADD_SUPPORTED_FIELD_TYPES}
-                                <option value="{$FIELD_TYPE}"
-                                        {foreach key=TYPE_INFO item=TYPE_INFO_VALUE from=$FIELD_TYPE_INFO[$FIELD_TYPE]}
-                                            data-{$TYPE_INFO}="{$TYPE_INFO_VALUE}"
-                                        {/foreach}>
-                                    {vtranslate($FIELD_TYPE, $QUALIFIED_MODULE)}
-                                </option>
-                            {/foreach}
-                        </select>
-                    </span>
+                    <select class="fieldTypesList" name="fieldType">
+                        {foreach item=FIELD_TYPE from=$ADD_SUPPORTED_FIELD_TYPES}
+                            <option value="{$FIELD_TYPE}"
+                                {foreach key=TYPE_INFO item=TYPE_INFO_VALUE from=$FIELD_TYPE_INFO[$FIELD_TYPE]}
+                                    data-{$TYPE_INFO}="{$TYPE_INFO_VALUE}"
+                                {/foreach}>
+                                {vtranslate($FIELD_TYPE, $QUALIFIED_MODULE)}
+                            </option>
+                        {/foreach}
+                    </select>
                 </div>
             </div>
             <div class="control-group">

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -1,3 +1,12 @@
 .clearfix {
 	clear: both;
 }
+.ui-autocomplete {
+    max-height: 400px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    width:300px;
+}
+.fieldTypesList {
+    min-width:28em;
+}


### PR DESCRIPTION
… of SELECT input in editor to accommodate them.

cr16: "Autocompleted text from list","Selbstvervollständigender Text aus Liste".
crs16: "Autocompleted text from list for single use", "Selbstvervollständigende Einmalwahl aus Liste"

Limited height of ajax autocomplete dropdown for possibly huge result sets for (future) remoteSQLsource fieldtype.