### PR TITLE
fix an issue with yearly workflows and scheduled reports where date w…

### DIFF
--- a/modules/com_vtiger_workflow/VTWorkflowManager.inc
+++ b/modules/com_vtiger_workflow/VTWorkflowManager.inc
@@ -657,8 +657,12 @@
 				if(!empty($nextTriggerDay)) {
 					$nextTime = date('Y:m:d H:i:s', strtotime($nextTriggerDay.' '.$scheduledTime));
 				} else {
+					//crm-now: if no date was found, just take day and month of next year (instead of adding only 1 year to the date the workflow/report was initially set up)
 					$nextTriggerDay = $annualDates[0];
-					$nextTime = date('Y:m:d H:i:s', strtotime($nextTriggerDay.' '.$scheduledTime.'+1 year'));
+					$nYear = date('Y', strtotime('+1 year'));
+					$arr_date = explode('-', $nextTriggerDay);
+					$arr_date[0] = $nYear;
+					$nextTime = implode('-', $arr_date).' '.$scheduledTime;
 				}
 			}
 			return $nextTime;


### PR DESCRIPTION
…as gotten from initial value (schannualdates fields) and only 1 year added to next trigger time, which could very well still be a date in the past

e.g. Workflow created to trigger first time on 2015-01-01, this value will be saved in schannualdates and is NEVER updated
next calculated trigger time would always be 2016-01-01, hence reports and workflows trigger every call