### PR TITLE
Fix imap folderview as in vtigercrm commit 10f2705fca89f870c254c6b65c…

### DIFF
--- a/pkg/vtiger/modules/MailManager/modules/MailManager/views/Folder.php
+++ b/pkg/vtiger/modules/MailManager/modules/MailManager/views/Folder.php
@@ -92,10 +92,14 @@ class MailManager_Folder_View extends MailManager_Abstract_View {
 			if ($this->hasMailboxModel()) {
 				$connector = $this->getConnector();
 
-				if (!$connector->hasError()) {
+				if ($connector->isConnected()) {
 					$folders = $connector->folders();
 					$connector->updateFolders();
 					$viewer->assign('FOLDERS', $folders);
+				} else if($connector->hasError()) {
+					$error = $connector->lastError();
+					$response->isJSON(true);
+					$response->setError(101, $error);
 				}
 				$this->closeConnector();
 			}


### PR DESCRIPTION
We saw no exchange-folders in the mailmanager. 
The issue was already fixed in vtigercrm commit 10f2705fca89f870c254c6b65c0a96842278ed4e, so we used their fix.