### PR TITLE
prevent slow MySQL transaction issues when more than one DB object is…

### DIFF
--- a/modules/Vtiger/CRMEntity.php
+++ b/modules/Vtiger/CRMEntity.php
@@ -25,9 +25,13 @@ class Vtiger_CRMEntity extends CRMEntity {
 	var $special_functions = Array('set_import_assigned_user');
 
 	function __construct() {
-		global $log;
+		global $log, $adb;
 		$this->column_fields = getColumnFields(get_class($this));
-		$this->db = new PearDatabase();
+		//try to prevent transaction issues when more than 1 DB object is used for queries
+		if (!isset($adb)) {
+			$adb = new PearDatabase();
+		}
+		$this->db = $adb;
 		$this->log = $log;
 	}
 


### PR DESCRIPTION
… used to perform queries inside a transaction block

e.g. restore() function where deleted flag update is done via $this->db (new PearDatabase) and ModTracker entry via global $adb