### PR TITLE
save new role-based picklist values to 'Organization' (H1) role

### DIFF
--- a/modules/Settings/Picklist/actions/SaveAjax.php
+++ b/modules/Settings/Picklist/actions/SaveAjax.php
@@ -71,7 +71,7 @@ class Settings_Picklist_SaveAjax_Action extends Settings_Vtiger_Basic_Action {
             $userSelectedRoles = $request->get('rolesSelected',array());
             //selected all roles option
             if(in_array('all',$userSelectedRoles)) {
-                $roleRecordList = Settings_Roles_Record_Model::getAll();
+                $roleRecordList = Settings_Roles_Record_Model::getAll(true);
                 foreach($roleRecordList as $roleRecord) {
                     $rolesSelected[] = $roleRecord->getId();
                 }


### PR DESCRIPTION
this will fix an issue with missing picklist values when a new role is created with H1 as parent role (values get copied from parent)