### PR TITLE
disable extractBody function, since this is not needed and not useful…

### DIFF
--- a/libraries/htmlpurifier/library/HTMLPurifier/Lexer.php
+++ b/libraries/htmlpurifier/library/HTMLPurifier/Lexer.php
@@ -364,17 +364,17 @@ class HTMLPurifier_Lexer
      */
     public function extractBody($html)
     {
-        $matches = array();
-        $result = preg_match('|(.*?)<body[^>]*>(.*)</body>|is', $html, $matches);
-        if ($result) {
+        // $matches = array();
+        // $result = preg_match('|(.*?)<body[^>]*>(.*)</body>|is', $html, $matches);
+        // if ($result) {
             // Make sure it's not in a comment
-            $comment_start = strrpos($matches[1], '<!--');
-            $comment_end   = strrpos($matches[1], '-->');
-            if ($comment_start === false ||
-                ($comment_end !== false && $comment_end > $comment_start)) {
-                return $matches[2];
-            }
-        }
+            // $comment_start = strrpos($matches[1], '<!--');
+            // $comment_end   = strrpos($matches[1], '-->');
+            // if ($comment_start === false ||
+                // ($comment_end !== false && $comment_end > $comment_start)) {
+                // return $matches[2];
+            // }
+        // }
         return $html;
     }
 }


### PR DESCRIPTION
… if email clients do not support <body> tags in html emails