### PR TITLE
fixed next ID in LineItems issue when an element was deleted (in the …

### DIFF
--- a/layouts/vlayout/modules/Inventory/resources/Edit.js
+++ b/layouts/vlayout/modules/Inventory/resources/Edit.js
@@ -463,7 +463,14 @@ Vtiger_Edit_Js("Inventory_Edit_Js",{
 
     loadRowSequenceNumber: function() {
 		if(this.rowSequenceHolder == false) {
-			this.rowSequenceHolder = jQuery('.' + this.rowClass, this.getLineItemContentsContainer()).length;
+			this.rowSequenceHolder = 1;
+			var parentO = this;
+			jQuery('.' + this.rowClass, this.getLineItemContentsContainer()).each(function (key, ele) {
+				var tmpIdNo = jQuery(ele).attr('id').replace(/row/, '');
+				if (tmpIdNo > parentO.rowSequenceHolder) {
+					parentO.rowSequenceHolder = tmpIdNo;
+				}
+			});
 		}
 		return this;
     },


### PR DESCRIPTION
…middle/start of the sequence) and another added

use highest number found (+1) now to prevent non-unique IDs in HTML DOM