### PR TITLE
converted Leads will no longer show up in RelatedLists if generic get…

### DIFF
--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -582,7 +582,7 @@ class CRMEntity {
 
             // crm-now: flag for appending data, preventing multiple appends (by save-triggered workflows f.e.)
             $append = $_REQUEST["add"][$fieldname]=="on" && !$_REQUEST["added"][$fieldname][$this->id] && !empty($_REQUEST[$fieldname]);
-			$_REQUEST["added"][$fieldname][$this->id]=true;
+            $_REQUEST["added"][$fieldname][$this->id]=true;
 
 			$typeofdata_array = explode("~", $typeofdata);
 			$datatype = $typeofdata_array[0];
@@ -1923,12 +1923,12 @@ class CRMEntity {
         // crm-now: double joined crmentityrel (instead of OR in join-condition) yielding *huge* performance boost
 		$query .= " FROM $other->table_name";
 		$query .= " INNER JOIN vtiger_crmentity ON vtiger_crmentity.crmid = $other->table_name.$other->table_index";
-		$query .= " LEFT JOIN vtiger_crmentityrel as entrel1 ON entrel1.relcrmid = vtiger_crmentity.crmid";
-		$query .= " LEFT JOIN vtiger_crmentityrel as entrel2 ON entrel2.crmid = vtiger_crmentity.crmid";
+		$query .= " LEFT JOIN vtiger_crmentityrel AS entrel1 ON (entrel1.relcrmid = vtiger_crmentity.crmid AND entrel1.crmid = $id)";
+		$query .= " LEFT JOIN vtiger_crmentityrel AS entrel2 ON (entrel2.crmid = vtiger_crmentity.crmid AND entrel2.relcrmid = $id)";
 		$query .= $more_relation;
 		$query .= " LEFT JOIN vtiger_users ON vtiger_users.id = vtiger_crmentity.smownerid";
 		$query .= " LEFT JOIN vtiger_groups ON vtiger_groups.groupid = vtiger_crmentity.smownerid";
-		$query .= " WHERE vtiger_crmentity.deleted = 0 AND (entrel2.relcrmid = $id OR entrel1.crmid = $id)";
+		$query .= " WHERE vtiger_crmentity.deleted = 0 AND (entrel1.crmid = $id OR entrel2.relcrmid = $id)";
 		$return_value = GetRelatedList($currentModule, $related_module, $other, $query, $button, $returnset);
 
 		if ($return_value == null)
@@ -2027,6 +2027,9 @@ class CRMEntity {
 			$query .= " LEFT  JOIN vtiger_groups       ON vtiger_groups.groupid = vtiger_crmentity.smownerid";
 
 			$query .= " WHERE vtiger_crmentity.deleted = 0 AND $this->table_name.$this->table_index = $id";
+			if ($related_module == 'Leads') {
+				$query .= " AND $other->table_name.converted <> 1";
+			}
 
 			$return_value = GetRelatedList($currentModule, $related_module, $other, $query, $button, $returnset);
 		}


### PR DESCRIPTION
…_dependents_list() function is used

re-applied missing changes for generic get_related_list() function performance issue caused by many entries in vtiger_crmentityrel