### PR TITLE
removed two problematic fields from Emails' fieldlist in QueryParser

### DIFF
--- a/include/Webservices/Custom/NewParser.php
+++ b/include/Webservices/Custom/NewParser.php
@@ -64,6 +64,12 @@ class berliQueryParser {
 			$queryGenerator->addCondition('activitytype','Emails','n','AND');
 		} else if ($elementType == 'Emails') {
 			$queryGenerator->addCondition('activitytype','Emails','e','AND');
+			if (isset($fieldObjects['filename'])) {
+				unset($fieldObjects['filename']);
+			}
+			if (isset($fieldObjects['access_count'])) {
+				unset($fieldObjects['access_count']);
+			}
 		}
 
 		// get field list


### PR DESCRIPTION
relation to filename is not defined in tab_name_index
filename and access_count relations would lead to INNER JOIN in QueryGenerator without necessarily having entries in those tables