### PR TITLE
allow module_no fields to be selected in import field mapping

### DIFF
--- a/modules/Vtiger/models/ModuleMeta.php
+++ b/modules/Vtiger/models/ModuleMeta.php
@@ -140,7 +140,7 @@ class Vtiger_ModuleMeta_Model extends Vtiger_Base_Model {
 			foreach($moduleFields as $fieldName => $fieldInstance) {
 				if(($this->isEditableField($fieldInstance)
 							&& ($fieldInstance->getTableName() != 'vtiger_crmentity' || $fieldInstance->getColumnName() != 'modifiedby')
-						) || ($fieldInstance->getUIType() == '70' && $fieldName != 'modifiedtime')) {
+						) || ($fieldInstance->getUIType() == '70' && $fieldName != 'modifiedtime') || $fieldInstance->getUIType() == 4) {
 					$importableFields[$fieldName] = $fieldInstance;
 				}
 			}


### PR DESCRIPTION
this will make their content readable and usable as duplicate indicator fields
their content cannot be updated this way