### PR TITLE
TT267 In config.php you can set

### DIFF
--- a/config.php
+++ b/config.php
@@ -17,7 +17,11 @@
  * The configuration file for FHS system
  * is located at /etc/vtigercrm directory.
  */
- 
+
 include('config.inc.php');
+
+// if 'true' then description field will be saved without smiles or another spezial symbols, only normal text. Default is false.
+global $set_utf8_special_chars_to_empty_string;
+$set_utf8_special_chars_to_empty_string = false;
 
 ?>


### PR DESCRIPTION
$set_utf8_special_chars_to_empty_string = true;
Then all special symbols, like smiles, will be replaced with empty string in description.